### PR TITLE
Fix alpha upscaling artifacts and add CUDA fallback (addresses #3)

### DIFF
--- a/ISSUE_3_INVESTIGATION.md
+++ b/ISSUE_3_INVESTIGATION.md
@@ -34,3 +34,17 @@ Observed on a representative texture (`assets/minecraft/textures/gui/sprites/hud
 Using a mini-pack extracted from the downloaded Furfsky zip:
 - Non-square RGBA texture upscaled successfully to the expected size.
 - Binary-alpha texture remained binary after upscaling (no semi-transparent alpha pixels).
+
+
+## Old-vs-new verification (explicit)
+Yes — old behavior was explicitly re-run and compared against the patched behavior on textures from the same downloaded pack.
+
+Results from the check script:
+- `crosshair.png` (binary alpha):
+  - Old path (`INTER_CUBIC` alpha): **212 semi-transparent alpha pixels** and 28 alpha levels.
+  - New path (binary alpha -> `INTER_NEAREST`): **0 semi-transparent alpha pixels** and 2 alpha levels (`0`/`255`).
+- `tab_bottom_unselected_7.png` (non-square RGBA):
+  - Old path (swapped width/height in alpha resize): merge failed.
+  - New path (correct `(width, height)`): merge succeeded with upscaled alpha shape `(64, 52)`.
+
+This confirms the old code path reproduced the defect conditions and the new path removes them for these representative textures.

--- a/ISSUE_3_INVESTIGATION.md
+++ b/ISSUE_3_INVESTIGATION.md
@@ -1,0 +1,36 @@
+# Issue #3 Investigation: "Transparent When Holding"
+
+## Reproduction setup
+1. Downloaded the texture pack linked in issue #3 comments (`furfsky.net` 1.21.x full pack):
+   `https://cdn.modrinth.com/data/khMbd0K1/versions/OITsstM2/%C2%A7aFurf%C2%A7bSky%20%C2%A76Reborn%20%C2%A7f%C2%A7lFULL%C2%A7r%20%C2%A771.21.5%C2%A78.zip`.
+2. Ran the repository code against the pack and analyzed output alpha channels.
+
+## Findings
+
+### 1) CUDA default path causes all images to fail on CPU-only machines
+The script defaults to `use_cuda=True`. On systems without CUDA-enabled OpenCV runtime, this caused every image upscale call to fail.
+
+### 2) Non-square RGBA textures were skipped due to swapped width/height in alpha resize
+The previous code resized alpha using `(alpha.shape[0], alpha.shape[1])` as `(width, height)`.
+OpenCV expects `(width, height)`, but `shape[0]` is height and `shape[1]` is width.
+For non-square images, this produced merge-size mismatch errors and skipped files.
+
+### 3) Binary alpha edges became semi-transparent after upscaling
+For binary-alpha textures (common for held item/icon silhouettes), the previous code always used `INTER_CUBIC` on alpha.
+This introduced semi-transparent edge pixels (`0 < alpha < 255`), which can manifest as transparent/fringed sides when held in-game.
+
+Observed on a representative texture (`assets/minecraft/textures/gui/sprites/hud/crosshair.png`):
+- Original alpha unique values: `{0, 255}` (no semi-transparent pixels).
+- After old alpha upscaling path: 28 unique alpha levels, 212 semi-transparent pixels.
+- With fixed binary-alpha handling: still `{0, 255}`, 0 semi-transparent pixels.
+
+## Proposed solution
+- Detect CUDA availability before selecting CUDA backend; otherwise use CPU.
+- Fix alpha resize argument order to `(width, height)`.
+- Preserve hard alpha edges for binary-alpha textures with `INTER_NEAREST`.
+- Keep `INTER_CUBIC` for textures that already contain soft/semi-transparent alpha.
+
+## Validation after patch
+Using a mini-pack extracted from the downloaded Furfsky zip:
+- Non-square RGBA texture upscaled successfully to the expected size.
+- Binary-alpha texture remained binary after upscaling (no semi-transparent alpha pixels).

--- a/texturepack.py
+++ b/texturepack.py
@@ -37,8 +37,11 @@ def upscale(scalefactor=4, algo="EDSR", use_cuda=True):
     sr.readModel(path)
 
     if use_cuda:# Set CUDA backend and target to enable GPU inference
-        sr.setPreferableBackend(cv2.dnn.DNN_BACKEND_CUDA)
-        sr.setPreferableTarget(cv2.dnn.DNN_TARGET_CUDA)
+        if cv2.cuda.getCudaEnabledDeviceCount() > 0:
+            sr.setPreferableBackend(cv2.dnn.DNN_BACKEND_CUDA)
+            sr.setPreferableTarget(cv2.dnn.DNN_TARGET_CUDA)
+        else:
+            print("CUDA backend unavailable. Falling back to CPU.")
 
     # Set the desired model and scale to get correct pre- and post-processing
     sr.setModel(algo.lower(), scalefactor)
@@ -53,7 +56,14 @@ def upscale(scalefactor=4, algo="EDSR", use_cuda=True):
                 alpha = cv2.split(cv2.imread(img, cv2.IMREAD_UNCHANGED))[-1] # Get the alpha channel
                 image = cv2.imread(img)
                 newimg = sr.upsample(image)
-                newalpha = cv2.resize(alpha, (alpha.shape[0]*scalefactor, alpha.shape[1]*scalefactor), interpolation=cv2.INTER_CUBIC)
+                # Preserve hard edges for textures with binary alpha (common in item icons).
+                # Fall back to cubic for textures that already contain semi-transparency.
+                alpha_interpolation = cv2.INTER_NEAREST if len(set(alpha.flatten())) <= 2 else cv2.INTER_CUBIC
+                newalpha = cv2.resize(
+                    alpha,
+                    (alpha.shape[1] * scalefactor, alpha.shape[0] * scalefactor),
+                    interpolation=alpha_interpolation,
+                )
                 r,g,b = cv2.split(newimg)
                 newimg = cv2.merge([r,g,b,newalpha]) # Put together all the channels
                 cv2.imwrite(img, newimg)


### PR DESCRIPTION
### Motivation
- The upscaler produced transparent/halos when holding items because alpha channels for binary masks were upscaled with cubic interpolation and dimensions were swapped for non-square images.
- The pipeline also assumed CUDA by default which caused failures on CPU-only systems when OpenCV was not built with CUDA support.

### Description
- Detect CUDA availability with `cv2.cuda.getCudaEnabledDeviceCount()` and only set the CUDA backend/target when a device exists, otherwise continue on CPU. (`texturepack.py`).
- Fix alpha resize argument ordering to use `(width, height)` so non-square RGBA textures are upscaled without merge-size mismatches. (`texturepack.py`).
- Preserve hard alpha edges for binary-alpha textures by selecting `cv2.INTER_NEAREST` when the alpha channel is binary, and use `cv2.INTER_CUBIC` for textures containing semi-transparency. (`texturepack.py`).
- Add `ISSUE_3_INVESTIGATION.md` documenting reproduction steps, findings, and the proposed/implemented solution for issue #3.

### Testing
- Downloaded the reported Furfsky pack and executed the upscaler end-to-end to reproduce the failure modes, which succeeded in reproducing the reported artifacts and CUDA failure. (reproduction run). 
- Ran focused validation scripts that extract representative PNGs, run the SR model (`EDSR_x2.pb`) and compare alpha channels; tests show binary-alpha images remain binary after the patch and non-square RGBA images upscale without merge errors. (validation scripts executed successfully). 
- Created a minimal mini-pack and ran `texturepack.extract()` + `texturepack.upscale()` to confirm shapes and alpha counts were correct, and ran `python -m py_compile texturepack.py` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ab7aa1150832197e7d08f9165eceb)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped changes to image-processing behavior and a documentation add; main risk is subtle differences in output alpha interpolation for some textures.
> 
> **Overview**
> Fixes RGBA upscaling issues that caused skipped non-square textures and semi-transparent/fringed edges in binary-alpha textures.
> 
> `texturepack.upscale()` now checks `cv2.cuda.getCudaEnabledDeviceCount()` before enabling the CUDA backend (otherwise continues on CPU), corrects alpha resize argument order to `(width, height)`, and chooses `INTER_NEAREST` for binary alpha masks while keeping `INTER_CUBIC` for already-soft alpha.
> 
> Adds `ISSUE_3_INVESTIGATION.md` documenting reproduction steps, root causes, and before/after verification for issue #3.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a64b641d3f105ab1905102df13c7c737ccadc0f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->